### PR TITLE
update phone_quests to fix time since epoch calculations

### DIFF
--- a/mods/smartphone/phone_quests/DOCS.md
+++ b/mods/smartphone/phone_quests/DOCS.md
@@ -1,2 +1,38 @@
 # Server Admin
 You can plan your month quests by editing the `QUESTS.lua` file in the `<YOUR_WORLD_FOLDER>/phone_quests/` folder. From there you'll be able to list which quests must be shown in the app, and when.
+
+# <YOUR_WORLD_FOLDER>/phone_quests/QUESTS.lua
+```
+phone_quests.start_day =  {year = 2024, month = 6,	day = 8, hour = 0, min = 0, sec = 0}
+```
+
+Set a custom epoch from which the days and weeks are calculated. The first day will last 24 hours from this point in system time, and the first week will last 7 days from this point in system time. The daily and weekly quests cycle after the defined number of weeks.
+
+```
+phone_quests.daily_quests = {
+    -- day 1 quests
+    {"quest_technical_name_day_1_quest_1",
+     "quest_technical_name_day_1_quest_2",},
+
+    -- day 2 quests
+    {"quest_technical_name_day_2_quest_1",
+     "quest_technical_name_day_2_quest_2",},
+
+    ...
+}
+```
+```
+phone_quests.weekly_quests = {
+    -- week 1 quests
+    {"quest_technical_name_week_1_quest_1",
+     "quest_technical_name_week_1_quest_2",},
+
+    -- week 2 quests
+    {"quest_technical_name_week_2_quest_1",
+     "quest_technical_name_week_2_quest_2",},
+
+    ...
+}
+```
+
+Quests are defined as ordered lists of days or weeks. Each entry for a day or week is a list of quest techical names. The quests shown in the app are chosen by this list for each day and week.

--- a/mods/smartphone/phone_quests/src/app.lua
+++ b/mods/smartphone/phone_quests/src/app.lua
@@ -17,12 +17,12 @@ local app_def = {
 			local quests_to_show = {}
 			local day = days_since_date(phone_quests.start_day)
 			if type == "weekly" then
-				local week = math.ceil(day / 7)
+				local week = math.floor(day / 7)
 				local weekly_quests = phone_quests.weekly_quests
-				quests_to_show = weekly_quests[week] or weekly_quests[(week % #weekly_quests) + 1]
+				quests_to_show = weekly_quests[((week) % #weekly_quests) + 1]
 			else
 				local daily_quests = phone_quests.daily_quests
-				quests_to_show = daily_quests[day] or daily_quests[(day % #daily_quests) + 1]
+				quests_to_show = daily_quests[((day) % #daily_quests) + 1]
 			end
 
 			return table.find(quests_to_show, function (valid_quest_name)
@@ -167,7 +167,7 @@ function days_since_date(date_table)
     
     -- Calculate the difference in seconds and convert to days
     local seconds_in_a_day = 86400
-    local difference_in_days = (current_timestamp - given_timestamp) / seconds_in_a_day
+    local difference_in_days = math.abs((current_timestamp - given_timestamp) / seconds_in_a_day)
     
     return math.floor(difference_in_days)
 end


### PR DESCRIPTION
With this update,
the time since the `start_date` is calculated properly.

Within 24 hours from the `start_date`, is day 1.
Within 7 days from the `start_date` is week 1.

Day/week changes occur in exact multiples of 24 hrs/7 days from the `start_date`