### PR TITLE
Fix quests resetting too early in unlock function and reset battle pass rewards simultaneously with weekly quests

### DIFF
--- a/mods/smartphone/phone_rewards/src/api.lua
+++ b/mods/smartphone/phone_rewards/src/api.lua
@@ -1,6 +1,18 @@
 local storage = minetest.get_mod_storage()
 
+minetest.register_on_joinplayer(function(player, last_login)
+	local weekly_quests = phone_quests.weekly_quests
+	local day = (phone_quests.days_since_date(phone_quests.start_day) % #weekly_quests) + 1
+	local week = math.floor(day / 7)
 
+	local last_joined_week_rewards_player = storage:get_int("last_joined_week_rewards")
+
+	if last_joined_week_rewards ~= week then
+		phone_rewards.reset_levels()
+	end
+
+	storage:set_int("last_joined_week_rewards", week)
+end)
 
 --[[
 	Gets the current points for a given player name.

--- a/mods/smartphone/satlantis_quests/src/triggers.lua
+++ b/mods/smartphone/satlantis_quests/src/triggers.lua
@@ -31,12 +31,11 @@ minetest.register_on_joinplayer(function(player, last_login)
 
     local daily_quests = phone_quests.daily_quests
 
-    local days_since_start = phone_quests.days_since_date(phone_quests.start_day)
-    local day = (days_since_start % #daily_quests) + 1
+    local day = phone_quests.days_since_date(phone_quests.start_day)
     local last_joined_day_quest = tonumber(storage:get_string("last_joined_day_quest|"..pl_name))
 
     if last_joined_day_quest ~= day then
-        local quests_to_modify = daily_quests[day]
+        local quests_to_modify = daily_quests[(day % #daily_quests) + 1]
         for index, quest in pairs(quests_to_modify) do
                 local data = awards.player(pl_name)
                 data.unlocked[quest] = nil
@@ -51,12 +50,13 @@ minetest.register_on_joinplayer(function(player, last_login)
 
     storage:set_string("last_joined_day_quest|"..pl_name, tostring(day))
 
-    local week = math.floor(days_since_start / 7)
+    local week = math.floor(day / 7)
     local last_joined_week_quest = storage:get_string("last_joined_week_quest|"..pl_name)
 
     if last_joined_week_quest ~= week then
         local weekly_quests = phone_quests.weekly_quests
-        local quests_to_modify = weekly_quests[week]
+        local quests_to_modify = weekly_quests[((week) % #weekly_quests) + 1]
+        minetest.log("warning", tostring(week))
         for index, quest in pairs(quests_to_modify) do
                 local data = awards.player(pl_name)
                 data.unlocked[quest] = nil

--- a/mods/smartphone/satlantis_quests/src/triggers.lua
+++ b/mods/smartphone/satlantis_quests/src/triggers.lua
@@ -35,23 +35,18 @@ minetest.register_on_joinplayer(function(player, last_login)
     local last_joined_day_quest = tonumber(storage:get_string("last_joined_day_quest|"..pl_name))
 
     if last_joined_day_quest ~= day then
-        local quests_modify_number = #daily_quests
+        quests_to_modify = daily_quests[day]
+        for index, quest in pairs(quests_to_modify) do
+                local data = awards.player(pl_name)
+                data.unlocked[quest] = nil
 
-        local quests_to_modify
-        for i = 1, quests_modify_number do
-            quests_to_modify = daily_quests[i]
-            for index, quest in pairs(quests_to_modify) do
-                    local data = awards.player(pl_name)
-                    data.unlocked[quest] = nil
-
-                    if awards.registered_awards[quest].trigger.node then
-                        local award_counter = awards.get_item_count(data, awards.registered_awards[quest].trigger.type, awards.registered_awards[quest].trigger.node) * -1
-                        awards.increment_item_counter(data, awards.registered_awards[quest].trigger.type, awards.registered_awards[quest].trigger.node, award_counter)
-                    end
-                    awards.save()
+                if awards.registered_awards[quest].trigger.node then
+                    local award_counter = awards.get_item_count(data, awards.registered_awards[quest].trigger.type, awards.registered_awards[quest].trigger.node) * -1
+                    awards.increment_item_counter(data, awards.registered_awards[quest].trigger.type, awards.registered_awards[quest].trigger.node, award_counter)
+                end
+                awards.save()
             end
         end
-    end
 
     storage:set_string("last_joined_day_quest|"..pl_name, tostring(day))
 
@@ -59,23 +54,17 @@ minetest.register_on_joinplayer(function(player, last_login)
     local last_joined_week_quest = storage:get_string("last_joined_week_quest|"..pl_name)
 
     if last_joined_week_quest ~= week then
-
         local weekly_quests = phone_quests.weekly_quests
-        local quests_modify_number = #weekly_quests
+        quests_to_modify = weekly_quests[week]
+        for index, quest in pairs(quests_to_modify) do
+                local data = awards.player(pl_name)
+                data.unlocked[quest] = nil
 
-        local quests_to_modify
-        for i = 1, quests_modify_number do
-            quests_to_modify = weekly_quests[i]
-            for index, quest in pairs(quests_to_modify) do
-                    local data = awards.player(pl_name)
-                    data.unlocked[quest] = nil
-
-                    if awards.registered_awards[quest].trigger.node then
-                        local award_counter = awards.get_item_count(data, awards.registered_awards[quest].trigger.type, awards.registered_awards[quest].trigger.node) * -1
-                        awards.increment_item_counter(data, awards.registered_awards[quest].trigger.type, awards.registered_awards[quest].trigger.node, award_counter)
-                    end
-                    awards.save()
-            end
+                if awards.registered_awards[quest].trigger.node then
+                    local award_counter = awards.get_item_count(data, awards.registered_awards[quest].trigger.type, awards.registered_awards[quest].trigger.node) * -1
+                    awards.increment_item_counter(data, awards.registered_awards[quest].trigger.type, awards.registered_awards[quest].trigger.node, award_counter)
+                end
+                awards.save()
         end
     end
 

--- a/mods/smartphone/satlantis_quests/src/triggers.lua
+++ b/mods/smartphone/satlantis_quests/src/triggers.lua
@@ -31,11 +31,12 @@ minetest.register_on_joinplayer(function(player, last_login)
 
     local daily_quests = phone_quests.daily_quests
 
-    local day = (phone_quests.days_since_date(phone_quests.start_day) % #daily_quests) + 1
+    local days_since_start = phone_quests.days_since_date(phone_quests.start_day)
+    local day = (days_since_start % #daily_quests) + 1
     local last_joined_day_quest = tonumber(storage:get_string("last_joined_day_quest|"..pl_name))
 
     if last_joined_day_quest ~= day then
-        quests_to_modify = daily_quests[day]
+        local quests_to_modify = daily_quests[day]
         for index, quest in pairs(quests_to_modify) do
                 local data = awards.player(pl_name)
                 data.unlocked[quest] = nil
@@ -50,12 +51,12 @@ minetest.register_on_joinplayer(function(player, last_login)
 
     storage:set_string("last_joined_day_quest|"..pl_name, tostring(day))
 
-    local week = math.floor(day / 7)
+    local week = math.floor(days_since_start / 7)
     local last_joined_week_quest = storage:get_string("last_joined_week_quest|"..pl_name)
 
     if last_joined_week_quest ~= week then
         local weekly_quests = phone_quests.weekly_quests
-        quests_to_modify = weekly_quests[week]
+        local quests_to_modify = weekly_quests[week]
         for index, quest in pairs(quests_to_modify) do
                 local data = awards.player(pl_name)
                 data.unlocked[quest] = nil

--- a/mods/smartphone_depends/awards/src/api_awards.lua
+++ b/mods/smartphone_depends/awards/src/api_awards.lua
@@ -54,10 +54,6 @@ function awards.unlock(name, award)
 	local awdef = awards.registered_awards[award]
 	assert(awdef, "Unable to unlock an award which doesn't exist!")
 
-	local award_counter = awards.get_item_count(data, awards.registered_awards[award].trigger.type, awards.registered_awards[award].trigger.node) * -1
-	awards.increment_item_counter(data, awards.registered_awards[award].trigger.type, awards.registered_awards[award].trigger.node, award_counter)
-	awards.save()
-
 	if data.disabled or
 			(data.unlocked[award] and data.unlocked[award] == award) then
 		return


### PR DESCRIPTION
The most recent commit is fixing quest resets too early, which makes it possible to earn points again by doing quests that are already gone.